### PR TITLE
Adds gitignore and makes functions in test-sweet.js available locally

### DIFF
--- a/spec/test-sweet_spec.js
+++ b/spec/test-sweet_spec.js
@@ -1,10 +1,4 @@
-const {
-  method,
-  represent,
-  it,
-  expect,
-  matchers
-} = require('../test-sweet')
+require('test-sweet')
 
 let executes = 0
 const noop = () => { executes += 1 }

--- a/spec/test_test.js
+++ b/spec/test_test.js
@@ -1,6 +1,5 @@
-require('../example.js')
 require('chalk')
-const { method, it, expect, matchers } = require('../test-sweet.js')
+require('test-sweet')
 
   method('FizzBuzz knows when something is', function() {
     it('divisible by 3', function() {

--- a/test-sweet.js
+++ b/test-sweet.js
@@ -1,7 +1,9 @@
 const chalk = require('chalk')
 const fs = require('fs')
 
-const matchers = (expression) => ({
+
+
+exports: matchers = (expression) => ({
   toEqual: function(assertion) {
     if (expression !== assertion) {
       console.log(chalk.red("🌚 " + expression + " isn't " + assertion))
@@ -38,24 +40,16 @@ var sweetieBar = function(result) {
   fs.appendFile('./sweets.txt', result + ' ', function(){})
 }
 
-const expect = (expression) => matchers(expression)
+exports: expect = (expression) => matchers(expression)
 
-const method = (name, expectations) => {
+exports: method = (name, expectations) => {
   console.log(name)
   expectations()
   }
 
-const represent = (name, expectations) => {
+exports: represent = (name, expectations) => {
   console.log(name)
   expectations()
   }
 
-const it = (can, doThis) => method(chalk.bold(can + '？'), doThis)
-
-module.exports = {
-  method,
-  represent,
-  it,
-  expect,
-  matchers
-}
+exports: it = (can, doThis) => method(chalk.bold(can + '？'), doThis)


### PR DESCRIPTION
Changes test-sweet.js exports
Now test files need to require('test-sweet')